### PR TITLE
refactor: move request validation from handlers to domain

### DIFF
--- a/api/handlers/alertmanager.go
+++ b/api/handlers/alertmanager.go
@@ -2,11 +2,13 @@ package handlers
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/gorilla/mux"
 	"github.com/odpf/siren/domain"
+	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"gopkg.in/go-playground/validator.v9"
-	"net/http"
 )
 
 func UpdateAlertCredentials(service domain.AlertmanagerService, logger *zap.Logger) http.HandlerFunc {
@@ -18,10 +20,10 @@ func UpdateAlertCredentials(service domain.AlertmanagerService, logger *zap.Logg
 			badRequest(w, err, logger)
 			return
 		}
-		v := validator.New()
-		err = v.Struct(alertCredential)
+		err = alertCredential.Validate()
 		if err != nil {
-			if _, ok := err.(*validator.InvalidValidationError); ok {
+			var e *validator.InvalidValidationError
+			if errors.As(err, &e) {
 				logger.Error("invalid validation error")
 				internalServerError(w, err, logger)
 				return

--- a/api/handlers/template.go
+++ b/api/handlers/template.go
@@ -20,10 +20,10 @@ func UpsertTemplates(service domain.TemplatesService, logger *zap.Logger) http.H
 			badRequest(w, err, logger)
 			return
 		}
-		v := validator.New()
-		err = v.Struct(template)
+		err = template.Validate()
 		if err != nil {
-			if _, ok := err.(*validator.InvalidValidationError); ok {
+			var e *validator.InvalidValidationError
+			if errors.As(err, &e) {
 				logger.Error("invalid validation error")
 				internalServerError(w, err, logger)
 				return

--- a/domain/alertmanager.go
+++ b/domain/alertmanager.go
@@ -1,5 +1,9 @@
 package domain
 
+import (
+	"gopkg.in/go-playground/validator.v9"
+)
+
 type SlackCredential struct {
 	Channel  string `json:"channel" validate:"required"`
 }
@@ -15,8 +19,14 @@ type AlertCredential struct {
 	PagerdutyCredentials string      `json:"pagerduty_credentials" validate:"required"`
 	SlackConfig          SlackConfig `json:"slack_config" validate:"required,dive,required"`
 }
+
 type AlertmanagerService interface {
 	Upsert(credential AlertCredential) error
 	Get(teamName string) (AlertCredential, error)
 	Migrate() error
+}
+
+func (ac *AlertCredential) Validate() error {
+	v := validator.New()
+	return v.Struct(ac)
 }

--- a/domain/rules.go
+++ b/domain/rules.go
@@ -1,6 +1,9 @@
 package domain
 
-import "time"
+import (
+	"time"
+	"gopkg.in/go-playground/validator.v9"
+)
 
 type RuleVariable struct {
 	Name        string `json:"name" validate:"required"`
@@ -27,4 +30,12 @@ type RuleService interface {
 	Upsert(*Rule) (*Rule, error)
 	Get(string, string, string, string, string) ([]Rule, error)
 	Migrate() error
+}
+
+func (rs *Rule) Validate() error {
+	v := validator.New()
+	_ = v.RegisterValidation("statusChecker", func(fl validator.FieldLevel) bool {
+		return fl.Field().Interface().(string) == "enabled" || fl.Field().Interface().(string) == "disabled"
+	})
+	return v.Struct(rs)
 }

--- a/domain/templates.go
+++ b/domain/templates.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"time"
+
+	"gopkg.in/go-playground/validator.v9"
 )
 
 type Variable struct {
@@ -29,4 +31,9 @@ type TemplatesService interface {
 	Delete(string) error
 	Render(string, map[string]string) (string, error)
 	Migrate() error
+}
+
+func (tm *Template) Validate() error {
+	v := validator.New()
+	return v.Struct(tm)
 }


### PR DESCRIPTION
Move request validation of alertmanager, rules and templates from handlers to domain.
Issue #38 